### PR TITLE
Adds initial support for plugin signing

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,20 +101,21 @@ type verifyCommand struct {
 
 func (v *verifyCommand) run(c *kingpin.ParseContext) error {
 	command := os.Getenv(`BUILDKITE_COMMAND`)
+	pluginJSON := os.Getenv(`BUILDKITE_PLUGINS`)
 	sig := os.Getenv(stepSignatureEnv)
 
-	if command == "" {
-		log.Println("No command set")
+	if command == "" && pluginJSON == "" {
+		log.Println("No command or plugins set")
 		return nil
 	}
 
-	err := v.Signer.Verify(command, Signature(sig))
+	err := v.Signer.Verify(command, pluginJSON, Signature(sig))
 
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	log.Println("Command signature matched")
+	log.Println("Signature matched")
 
 	return nil
 }

--- a/plugins.go
+++ b/plugins.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+var (
+	// 'official-plugin' and 'official-plugin#v2'
+	officialPluginRegex = regexp.MustCompile(`^([A-Za-z0-9-]+)(#.+)?$`)
+	// 'some-org/some-plugin' and 'some-org/some-plugin#v2'
+	githubPluginRegex = regexp.MustCompile(`^([A-Za-z0-9-]+\/[A-Za-z0-9-]+)(#.+)?$`)
+)
+
+type Plugin struct {
+	Name   string
+	Params map[string]interface{}
+}
+
+func (p Plugin) Repository() string {
+	if m := officialPluginRegex.FindStringSubmatch(p.Name); len(m) == 3 {
+		return fmt.Sprintf(`github.com/buildkite-plugins/%s-buildkite-plugin%s`, m[1], m[2])
+	}
+	if m := githubPluginRegex.FindStringSubmatch(p.Name); len(m) == 3 {
+		return fmt.Sprintf(`github.com/%s-buildkite-plugin%s`, m[1], m[2])
+	}
+	return p.Name
+}
+
+// The bootstrap expects an array of plugins like [{"plugin1#v1.0.0":{...}}, {"plugin2#v1.0.0":{...}}]
+func marshalPlugins(plugins []Plugin) (string, error) {
+	var p []interface{}
+	for _, plugin := range plugins {
+		p = append(p, map[string]interface{}{
+			plugin.Repository(): plugin.Params,
+		})
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return "", nil
+	}
+	return string(b), nil
+}

--- a/signer_test.go
+++ b/signer_test.go
@@ -54,8 +54,13 @@ func TestPipelines(t *testing.T) {
 		},
 		{
 			"Step with no command",
+			`{"steps":[{"label":"I have no commands"}]}`,
+			`{"steps":[{"label":"I have no commands"}]}`,
+		},
+		{
+			"Step plugins, but no commands",
 			`{"steps":[{"label":"I have no commands","plugins":[{"docker#v1.4.0":{"image":"node:7"}}]}]}`,
-			`{"steps":[{"label":"I have no commands","plugins":[{"docker#v1.4.0":{"image":"node:7"}}]}]}`,
+			`{"steps":[{"env":{"STEP_SIGNATURE":"acee5ed57eea7fb6388e3349677f1ec85ce55e131c7ba56b7093218f5be24a6b"},"label":"I have no commands","plugins":[{"docker#v1.4.0":{"image":"node:7"}}]}]}`,
 		},
 		{
 			"Pipeline with multiple steps",
@@ -65,7 +70,7 @@ func TestPipelines(t *testing.T) {
 		{
 			"Empty command",
 			`{"steps":[{"command":""}]}`,
-			`{"steps":[{"command":"","env":{"STEP_SIGNATURE":"95f900c45e3ada0027266909f4038f8374a7b234b396aa47db54f2a76522b7d4"}}]}`,
+			`{"steps":[{"command":""}]}`,
 		},
 		{
 			"Wait step",
@@ -81,6 +86,11 @@ func TestPipelines(t *testing.T) {
 			"Wait with steps",
 			`{"steps":[{"block":"Does this work?","prompt":"Yes"},"wait",{"command":"echo done"}]}`,
 			`{"steps":[{"block":"Does this work?","prompt":"Yes"},"wait",{"command":"echo done","env":{"STEP_SIGNATURE":"7314596562367a9a0fe297ea47d32416d9039b064e14f39aed84170bdc4c6574"}}]}`,
+		},
+		{
+			"Step with plugins",
+			"{\"steps\":[{\"command\":\"echo Hello World\",\"plugins\":[{\"github.com/seek-oss/snyk-buildkite-plugin#v0.0.4\":{\"path\":\"package.json\",\"block\":true}},{\"github.com/seek-oss/aws-sm-buildkite-plugin#v0.0.5\":{\"env\":{\"XX\":\"name\"}}}]}]}",
+			"{\"steps\":[{\"command\":\"echo Hello World\",\"env\":{\"STEP_SIGNATURE\":\"c6b6e6344b52b2ce57bd13ba05e0b63ef48364dda962c300bb210cd5be3898ef\"},\"plugins\":[{\"github.com/seek-oss/snyk-buildkite-plugin#v0.0.4\":{\"path\":\"package.json\",\"block\":true}},{\"github.com/seek-oss/aws-sm-buildkite-plugin#v0.0.5\":{\"env\":{\"XX\":\"name\"}}}]}]}",
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
This add initial support for signing plugins. Keen for feedback on the approach as ordering of the plugin JSON is important. We'll also need to expand the plugin sources per the current Buildkite behaviour.

TODO:
 - [x] Implement plugin URL expansion rules per https://buildkite.com/docs/pipelines/plugins#plugin-sources and https://github.com/buildkite/agent/pull/762/files#diff-e46069f38e288ad2a2206cab78dcbde7
 - [x] Parse/process the plugin parameters in order per https://github.com/buildkite/agent/pull/824