### PR TITLE
Prefixes the signature with the hashing algorithm

### DIFF
--- a/signer.go
+++ b/signer.go
@@ -186,7 +186,7 @@ func (s SharedSecretSigner) signData(command string, pluginJSON string) (Signatu
 	h := hmac.New(sha256.New, []byte(s.secret))
 	h.Write([]byte(strings.TrimSpace(command)))
 	h.Write([]byte(pluginJSON))
-	return Signature(fmt.Sprintf("%x", h.Sum(nil))), nil
+	return Signature(fmt.Sprintf("sha256:%x", h.Sum(nil))), nil
 }
 
 func (s SharedSecretSigner) Verify(command string, pluginJSON string, expected Signature) error {

--- a/signer_test.go
+++ b/signer_test.go
@@ -24,7 +24,7 @@ func TestSigningCommand(t *testing.T) {
 	}
 
 	j, err := json.Marshal(signed)
-	assert.Equal(t, `{"steps":[{"command":"echo Hello \"Fred\"","env":{"STEP_SIGNATURE":"a3ea512c6a88aa490d50879ef7ad7e3bc27c6f286435a9660fb662960e63592c"}}]}`, string(j))
+	assert.Equal(t, `{"steps":[{"command":"echo Hello \"Fred\"","env":{"STEP_SIGNATURE":"sha256:a3ea512c6a88aa490d50879ef7ad7e3bc27c6f286435a9660fb662960e63592c"}}]}`, string(j))
 }
 
 func TestSigningCommandWithPlugins(t *testing.T) {


### PR DESCRIPTION
This closes #10 by prefixing the signature with `sha256:`