### PR TITLE
Adds support for AWS SM stored secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ fi
 
 This step will fail if the provided signatures aren't in the environment.
 
+## Managing signing secrets
+
+### Simple secret
+
+Per the examples above, the secret for signing and verification can be provided via an environment variable or command line flag.
+
+### AWS SM
+
+This tool also has first-class support for [AWS Secrets Manager (AWS SM)](https://aws.amazon.com/secrets-manager/).
+A secret id or ARN can be provided, the secret value will then be fetched from AWS SM to be used for signing and verification.
+
+```bash
+export SIGNED_PIPELINE_AWS_SM_SECRET_ID='arn:aws:secretsmanager:ap-southeast-2:12345:secret:my-signed-pipeline-secret-42a5qP'
+
+buildkite-signed-pipeline upload
+```
+
+Future versions of the tool will add support for secret versioning.
+
 ## How it works
 
 When the tool receives a pipeline for upload, it follows these steps:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/seek-oss/buildkite-signed-pipeline
 require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+	github.com/aws/aws-sdk-go v1.15.45
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,14 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/aws/aws-sdk-go v1.15.45 h1:AZQmbZllwfzmoGWnCufXcPEObmdOh4Jb9EiIweh/4Sg=
+github.com/aws/aws-sdk-go v1.15.45/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-ini/ini v1.25.4 h1:Mujh4R/dH6YL8bxuISne3xX2+qcQ9p0IxKAP6ExWoUo=
+github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=

--- a/main.go
+++ b/main.go
@@ -51,6 +51,9 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		log.Printf("Using secret from AWS SM %s", *awsSmSecretId)
+	} else {
+		log.Println("Using shared secret from env/cli")
 	}
 	signer := NewSharedSecretSigner(rawSecret)
 


### PR DESCRIPTION
This closes #5 by adding basic AWS SM support. This means callers do not have to expose the secret in an environment variable (making it less likely to be logged).

~This is on top of PR #12 -- so ignore the first commit from this review.~

Secret versions aren't yet leveraged, but that'll be tackled during rotation support (#6)