### PR TITLE
Support unsigned command verification into the tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ buildkite-signed-pipeline upload
 In a global `environment` hook, you can include the following to ensure that all jobs that are handed to an agent contain the correct signatures:
 
 ```bash
-# Allow the upload command to be unsigned, as it typically comes from the Buildkite UI and not your agents
-if [[ "${BUILDKITE_COMMAND}" == "buildkite-signed-pipeline upload" ]]; then
-  echo "Allowing pipeline upload"
-  exit 0
-fi
-
 export SIGNED_PIPELINE_SECRET='my secret'
 
 if ! buildkite-signed-pipeline verify ; then
@@ -36,6 +30,31 @@ fi
 ```
 
 This step will fail if the provided signatures aren't in the environment.
+
+#### Allowing initial commands
+
+By default the tool will allow steps through without a signature, this allows commands to be specified in the Buildkite UI -- for example the initial pipeline upload command.
+
+The rules for allowing such commands are:
+
+ 1. `BUILDKITE_COMMAND` is (by default) `buildkite-signed-pipline upload`; **and**
+ 2. `BUILDKITE_PLUGINS` is empty/unset; **and**
+ 3. `STEP_SIGNATURE` is empty/unset
+
+Additional commands can be specified with `--allow-unsigned-command`:
+
+```bash
+export SIGNED_PIPELINE_SECRET='my secret'
+
+buildkite-signed-pipeline verify                                          \
+  --allow-unsigned-command="buildkite-signed-pipline upload"              \
+  --allow-unsigned-command="buildkite-signed-pipeline upload ./test.yml"
+
+if [[ $? -ne 0 ]] ; then
+  echo "Step verification failed"
+  exit 1
+fi
+```
 
 ## Managing signing secrets
 

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	verifyCommand := &verifyCommand{}
 	app.Command("verify", "Verify a job contains a signature").Action(verifyCommand.run)
 
-	app.PreAction(func(c *kingpin.ParseContext) error {
+	app.Action(func(c *kingpin.ParseContext) error {
 		if sharedSecret == "" && awsSharedSecretId == "" {
 			return errors.New("One of --shared-secret or --aws-sm-shared-secret-id must be provided")
 		}

--- a/signer.go
+++ b/signer.go
@@ -189,17 +189,44 @@ func (s SharedSecretSigner) signData(command string, pluginJSON string) (Signatu
 	return Signature(fmt.Sprintf("sha256:%x", h.Sum(nil))), nil
 }
 
-func (s SharedSecretSigner) Verify(command string, pluginJSON string, expected Signature) error {
-	signature, err := s.signData(command, pluginJSON)
+func (s SharedSecretSigner) Verify(command string, pluginJSON string, allowedUnsignedCommands []string, expected Signature) error {
+	// Allow any command on the unsigned list to be verified provided it has no signature and plugins.
+	// Checking there's no signature is important to ensure plugins aren't being injected with a
+	// command on the built-in allow list
+	if contains(allowedUnsignedCommands, command) {
+		log.Println("Command is on the allowed list of unsigned commands")
+		if expected == "" && pluginJSON == "" {
+			log.Println("✅ Allowing allow-listed command as no signature is specified, and no plugins are referenced")
+			return nil
+		}
+		log.Println("❗️Forcing signature check as pstep has an expected signature or referenced plugins")
+	}
+
+	// allow signerFunc to be overwritten in tests
+	signerFunc := s.signerFunc
+	if signerFunc == nil {
+		signerFunc = s.signData
+	}
+
+	signature, err := signerFunc(command, pluginJSON)
 
 	if err != nil {
 		return err
 	}
 
 	if signature != expected {
-		return errors.New("🚨 Signature mismatch." +
+		return errors.New("🚨 Signature mismatch. " +
 			"Perhaps check the shared secret is the same across agents?")
 	}
 
 	return nil
+}
+
+func contains(hayStack []string, needle string) bool {
+	for _, item := range hayStack {
+		if item == needle {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This closes #14 by allowing a list of commands to be specified that can remain unsigned. This ensures plugins are still verified, and/or the step is still verified if a step signature is found.

I'll look at a "command eval" style approach in a future PR -- e.g. any script in the repository may be executed by default.