### PR TITLE
Include BUILDKITE_JOB_ID in signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ When the tool receives a pipeline for upload, it follows these steps:
 * Iterates through each step of a JSON pipeline
 * Extracts the `command` or `commands` block
 * Trims whitespace on resulting command
-* Calculates `HMAC(SHA256, command + canonicalised(BUILDKITE_PLUGINS), shared-secret)`
+* Calculates `HMAC(SHA256, command + BUILDKITE_JOB_ID + canonicalised(BUILDKITE_PLUGINS), shared-secret)`
 * Add `STEP_SIGNATURE={hash}` to the step `environment` block
 * Pipes the modified JSON pipeline to `buildkite-agent pipeline upload`
 
 When the tool is verifying a pipeline:
 
-* Calculates `HMAC(SHA256, BUILDKITE_COMMAND + canonicalised(BUILDKITE_PLUGINS), shared-secret)`
+* Calculates `HMAC(SHA256, BUILDKITE_COMMAND + BUILDKITE_JOB_ID + canonicalised(BUILDKITE_PLUGINS), shared-secret)`
 * Compare result with `STEP_SIGNATURE`
 * Fail if they don't match
 

--- a/signer.go
+++ b/signer.go
@@ -4,14 +4,16 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"errors"
-	"log"
 	"fmt"
+	"log"
+	"os"
 	"reflect"
 	"strings"
 )
 
 const (
-	stepSignatureEnv = `STEP_SIGNATURE`
+	stepSignatureEnv  = `STEP_SIGNATURE`
+	buildkiteJobIDEnv = `BUILDKITE_JOB_ID`
 )
 
 func NewSharedSecretSigner(secret string) *SharedSecretSigner {
@@ -185,6 +187,7 @@ type Signature string
 func (s SharedSecretSigner) signData(command string, pluginJSON string) (Signature, error) {
 	h := hmac.New(sha256.New, []byte(s.secret))
 	h.Write([]byte(strings.TrimSpace(command)))
+	h.Write([]byte(os.Getenv(buildkiteJobIDEnv)))
 	h.Write([]byte(pluginJSON))
 	return Signature(fmt.Sprintf("sha256:%x", h.Sum(nil))), nil
 }


### PR DESCRIPTION
This includes `BUILDKITE_JOB_ID` in the signature, which prevents replay attacks where an attacker records a signed command and can replay it in future. 