### PR TITLE
Add very basic unsigned command validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ buildkite-signed-pipeline upload
 In a global `environment` hook, you can include the following to ensure that all jobs that are handed to an agent contain the correct signatures:
 
 ```bash
-# Allow the upload command to be unsigned, as it typically comes from the Buildkite UI and not your agents
-if [[ "${BUILDKITE_COMMAND}" == "buildkite-signed-pipeline upload" ]]; then
-  echo "Allowing pipeline upload"
-  exit 0
-fi
-
 export SIGNED_PIPELINE_SECRET='my secret'
 
 if ! buildkite-signed-pipeline verify ; then
@@ -35,7 +29,8 @@ if ! buildkite-signed-pipeline verify ; then
 fi
 ```
 
-This step will fail if the provided signatures aren't in the environment.
+This step will fail if the provided signatures aren't in the environment. The tool allows `buildkite-signed-pipeline upload` to be executed without a signature,
+this allows the initial upload step to be entered into the Buildkite UI.
 
 ## Managing signing secrets
 

--- a/main.go
+++ b/main.go
@@ -138,7 +138,8 @@ func (v *verifyCommand) run(c *kingpin.ParseContext) error {
 		return nil
 	}
 
-	err := v.Signer.Verify(command, pluginJSON, Signature(sig))
+	unsignedCommandValidator := UnsignedCommandValidator{}
+	err := v.Signer.Verify(command, pluginJSON, unsignedCommandValidator, Signature(sig))
 
 	if err != nil {
 		log.Fatalln(err)

--- a/main.go
+++ b/main.go
@@ -138,9 +138,7 @@ func (v *verifyCommand) run(c *kingpin.ParseContext) error {
 		return nil
 	}
 
-	unsignedCommandValidator := UnsignedCommandValidator{}
-	err := v.Signer.Verify(command, pluginJSON, unsignedCommandValidator, Signature(sig))
-
+	err := v.Signer.Verify(command, pluginJSON, Signature(sig))
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/signer.go
+++ b/signer.go
@@ -219,7 +219,7 @@ func (s SharedSecretSigner) Verify(command string, pluginJSON string, unsignedCo
 	}
 
 	if signature != expected {
-		return errors.New("🚨 Signature mismatch." +
+		return errors.New("🚨 Signature mismatch. " +
 			"Perhaps check the shared secret is the same across agents?")
 	}
 

--- a/signer.go
+++ b/signer.go
@@ -204,7 +204,7 @@ func (s SharedSecretSigner) Verify(command string, pluginJSON string, unsignedCo
 			log.Printf("Allowing unsigned command")
 			return nil
 		}
-		return errors.New("🚨 Command is unsigned, and it's not in the list of allowed unsigned commands")
+		return errors.New("🚨 Signature missing. The provided command is not permitted to be unsigned.")
 	}
 
 	// allow signerFunc to be overwritten in tests

--- a/unsigned_commands.go
+++ b/unsigned_commands.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+	"path/filepath"
+	"os"
+)
+
+var (
+	RawUploadCommand string = "buildkite-signed-pipeline upload"
+)
+
+type UnsignedCommandValidator struct {}
+
+func (u UnsignedCommandValidator) Allowed(command string) (bool, error) {
+	if command == RawUploadCommand {
+		return true, nil
+	}
+
+	uploadPrefix := RawUploadCommand + " "
+	// If there's no additional arguments, bail early
+	if !strings.HasPrefix(command, uploadPrefix) {
+		return false, nil
+	}
+
+	fileArgument := strings.TrimPrefix(command, uploadPrefix)
+	isLocal, err := isWorkingDirectoryFile(fileArgument)
+
+	if err != nil {
+		return false, err
+	}
+
+	return isLocal, nil
+}
+
+func isWorkingDirectoryFile(fileName string) (bool, error) {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return false, err
+	}
+	pathToFile, err := filepath.Abs(filepath.Join(workingDirectory, fileName))
+	return err == nil && fileExists(pathToFile), nil
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}

--- a/unsigned_commands.go
+++ b/unsigned_commands.go
@@ -31,12 +31,20 @@ func IsUnsignedCommandOk(command string) (bool, error) {
 }
 
 func isWorkingDirectoryFile(fileName string) (bool, error) {
+	// this is based on https://github.com/buildkite/agent/blob/cc07aba854e35f0f31b0d743d7ec2829b425bb6a/bootstrap/bootstrap.go#L1013-L1030
+	// and ensures the given filename exists in the working directory
 	workingDirectory, err := os.Getwd()
 	if err != nil {
 		return false, err
 	}
 	pathToFile, err := filepath.Abs(filepath.Join(workingDirectory, fileName))
-	return err == nil && fileExists(pathToFile), nil
+	if err != nil {
+		return false, err
+	}
+
+	// Make sure the file is definitely within this working directory
+	return fileExists(pathToFile) &&
+		strings.HasPrefix(pathToFile, workingDirectory + string(os.PathSeparator)), nil
 }
 
 func fileExists(filename string) bool {

--- a/unsigned_commands.go
+++ b/unsigned_commands.go
@@ -6,18 +6,16 @@ import (
 	"os"
 )
 
-var (
-	RawUploadCommand string = "buildkite-signed-pipeline upload"
-)
+const rawUploadCommand string = "buildkite-signed-pipeline upload"
 
 type UnsignedCommandValidator struct {}
 
 func (u UnsignedCommandValidator) Allowed(command string) (bool, error) {
-	if command == RawUploadCommand {
+	if command == rawUploadCommand {
 		return true, nil
 	}
 
-	uploadPrefix := RawUploadCommand + " "
+	uploadPrefix := rawUploadCommand + " "
 	// If there's no additional arguments, bail early
 	if !strings.HasPrefix(command, uploadPrefix) {
 		return false, nil

--- a/unsigned_commands.go
+++ b/unsigned_commands.go
@@ -3,14 +3,13 @@ package main
 import (
 	"strings"
 	"path/filepath"
+	"fmt"
 	"os"
 )
 
-const rawUploadCommand string = "buildkite-signed-pipeline upload"
+func IsUnsignedCommandOk(command string) (bool, error) {
+	rawUploadCommand := fmt.Sprintf("%s upload", filepath.Base(os.Args[0]))
 
-type UnsignedCommandValidator struct {}
-
-func (u UnsignedCommandValidator) Allowed(command string) (bool, error) {
 	if command == rawUploadCommand {
 		return true, nil
 	}

--- a/unsigned_commands_test.go
+++ b/unsigned_commands_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"testing"
 	"os"
 	"path/filepath"
@@ -33,6 +34,11 @@ func TestUnsignedCommandValidation(t *testing.T) {
 			true,
 		},
 		{
+			"Upload with relative argument inside working directory",
+			fmt.Sprintf("%s upload .git/../go.mod", thisTool),
+			true,
+		},
+		{
 			"Upload with not found file argument",
 			fmt.Sprintf("%s upload missing-file.yaml", thisTool),
 			false,
@@ -46,4 +52,23 @@ func TestUnsignedCommandValidation(t *testing.T) {
 			assert.Equal(t, isAllowed, tc.Expected)
 		})
 	}
+}
+
+func TestUnsignedCommandWithOutsideFile(t *testing.T) {
+	thisTool := filepath.Base(os.Args[0])
+
+	workingDirectory, err := os.Getwd()
+	assert.Nil(t, err)
+
+	tempFile, err := ioutil.TempFile("", "outside")
+	assert.Nil(t, err)
+	defer os.Remove(tempFile.Name())
+
+	// create a path relative to the outside file, this will be something like ../../../tmp/foo
+	relPath, err := filepath.Rel(workingDirectory, tempFile.Name())
+
+	command := fmt.Sprintf("%s upload %s", thisTool, relPath)
+	isAllowed, err := IsUnsignedCommandOk(command)
+	assert.Nil(t, err)
+	assert.False(t, isAllowed)
 }

--- a/unsigned_commands_test.go
+++ b/unsigned_commands_test.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"fmt"
 	"testing"
+	"os"
+	"path/filepath"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestUnsignedCommandValidation(t *testing.T) {
+	thisTool := filepath.Base(os.Args[0])
+
 	for _, tc := range []struct {
 		Name         string
 		Command      string
@@ -19,23 +24,22 @@ func TestUnsignedCommandValidation(t *testing.T) {
 		},
 		{
 			"Simple signed upload",
-			"buildkite-signed-pipeline upload",
+			fmt.Sprintf("%s upload", thisTool),
 			true,
 		},
 		{
 			"Upload with existing file argument",
-			"buildkite-signed-pipeline upload go.mod",
+			fmt.Sprintf("%s upload go.mod", thisTool),
 			true,
 		},
 		{
 			"Upload with not found file argument",
-			"buildkite-signed-pipeline upload missing-file.yaml",
+			fmt.Sprintf("%s upload missing-file.yaml", thisTool),
 			false,
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			validator := UnsignedCommandValidator{}
-			isAllowed, err := validator.Allowed(tc.Command)
+			isAllowed, err := IsUnsignedCommandOk(tc.Command)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/unsigned_commands_test.go
+++ b/unsigned_commands_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnsignedCommandValidation(t *testing.T) {
+	for _, tc := range []struct {
+		Name         string
+		Command      string
+		Expected     bool
+	}{
+		{
+			"Normal buildkite upload",
+			"buildkite-agent pipeline upload",
+			false,
+		},
+		{
+			"Simple signed upload",
+			"buildkite-signed-pipeline upload",
+			true,
+		},
+		{
+			"Upload with existing file argument",
+			"buildkite-signed-pipeline upload go.mod",
+			true,
+		},
+		{
+			"Upload with not found file argument",
+			"buildkite-signed-pipeline upload missing-file.yaml",
+			false,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			validator := UnsignedCommandValidator{}
+			isAllowed, err := validator.Allowed(tc.Command)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, isAllowed, tc.Expected)
+		})
+	}
+}


### PR DESCRIPTION
This adds some "smart" command validation for allowing `buildkite-signed-pipeline upload <optional file>` to be allowed through without a signature.

I've put this up early as I'm keen for your feedback on this approach @lox 

I toyed with the idea of parsing the command with kingpin but:
 1. [`Application.Parse`](https://godoc.org/github.com/alecthomas/kingpin#Application.Parse) only accepts split up commands (`string[]`) vs a single `string`; and
 2. This relies on the command parsing library for security (e.g. does it ignore shell backticks? variable expansion? etc)

TODO:
 - [x] Use it during verify, making sure to force a signature check if a signature is found, or there are plugins used in the step
 - [x] Consider argument quoting/additional arguments, etc