### PR TITLE
Adds support for signing plugins that have no arguments

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -18,13 +18,13 @@ type Plugin struct {
 }
 
 func NewPluginFromReference(item interface{}) (*Plugin, error) {
-	switch item.(type) {
+	switch i := item.(type) {
 	// plugin references that are just a plugin name, e.g. docker#v1.2.3
 	case string:
-		return &Plugin{item.(string), nil}, nil
+		return &Plugin{i, nil}, nil
 	// plugin references that are a name and a set of settings
 	case map[string]interface{}:
-		for name, settings := range item.(map[string]interface{}) {
+		for name, settings := range i {
 			// note that x.(T) is avoided here as settings may be null in the case
 			// of plugins without parameters
 			parameters, _ := settings.(map[string]interface{})

--- a/signer_test.go
+++ b/signer_test.go
@@ -121,6 +121,16 @@ func TestPipelines(t *testing.T) {
 			`{"steps":[{"env":{"STEP_SIGNATURE":"signature(,[{\"github.com/buildkite-plugins/docker-buildkite-plugin#v1.4.0\":{\"image\":\"node:7\"}}])"},"label":"I have no commands","plugins":[{"docker#v1.4.0":{"image":"node:7"}}]}]}`,
 		},
 		{
+			"Plugin object syntax without arguments",
+			`{"steps":[{"label":"I have no commands","plugins":[{"docker#v1.4.0":null}]}]}`,
+			`{"steps":[{"env":{"STEP_SIGNATURE":"signature(,[{\"github.com/buildkite-plugins/docker-buildkite-plugin#v1.4.0\":null}])"},"label":"I have no commands","plugins":[{"docker#v1.4.0":null}]}]}`,
+		},
+		{
+			"Plugin array syntax without arguments",
+			`{"steps":[{"label":"I have no commands","plugins":["docker#v1.4.0"]}]}`,
+			`{"steps":[{"env":{"STEP_SIGNATURE":"signature(,[{\"github.com/buildkite-plugins/docker-buildkite-plugin#v1.4.0\":null}])"},"label":"I have no commands","plugins":["docker#v1.4.0"]}]}`,
+		},
+		{
 			"Pipeline with multiple steps",
 			`{"steps":[{"command":"echo hello"},{"commands":["echo world", "echo foo"]}]}`,
 			`{"steps":[{"command":"echo hello","env":{"STEP_SIGNATURE":"signature(echo hello,)"}},{"commands":["echo world","echo foo"],"env":{"STEP_SIGNATURE":"signature(echo world\necho foo,)"}}]}`,


### PR DESCRIPTION
This fixes #24 by substituting missing plugin arguments with "null" when creating a signature. This reflects the behaviour of Buildkite where:
```
steps:
  - command: 'echo wow'
    plugins:
      - docker#v2.0.0
```

Will result in `BUILDKITE_PLUGINS` being `{"github.com/buildkite-plugins/docker-buildkite-plugin#v2.0.0":null}]`