### PR TITLE
Allow buildkite-agent pipeline upload to be unsigned

### DIFF
--- a/unsigned_commands.go
+++ b/unsigned_commands.go
@@ -7,14 +7,33 @@ import (
 	"os"
 )
 
-func IsUnsignedCommandOk(command string) (bool, error) {
+func getUploadCommand(command string) (string, bool) {
+	// buildkite-signed-pipeline upload
 	rawUploadCommand := fmt.Sprintf("%s upload", filepath.Base(os.Args[0]))
+	if strings.HasPrefix(command, rawUploadCommand) {
+		return rawUploadCommand, true
+	}
 
-	if command == rawUploadCommand {
+	vanillaUploadCommand := "buildkite-agent pipeline upload"
+	if strings.HasPrefix(command, vanillaUploadCommand) {
+		return vanillaUploadCommand, true
+	}
+
+	return "", false
+}
+
+func IsUnsignedCommandOk(command string) (bool, error) {
+	uploadCommand, ok := getUploadCommand(command)
+	if !ok {
+		return false, nil
+	}
+
+	// straight upload
+	if uploadCommand == command {
 		return true, nil
 	}
 
-	uploadPrefix := rawUploadCommand + " "
+	uploadPrefix := uploadCommand + " "
 	// If there's no additional arguments, bail early
 	if !strings.HasPrefix(command, uploadPrefix) {
 		return false, nil

--- a/unsigned_commands_test.go
+++ b/unsigned_commands_test.go
@@ -21,7 +21,12 @@ func TestUnsignedCommandValidation(t *testing.T) {
 		{
 			"Normal buildkite upload",
 			"buildkite-agent pipeline upload",
-			false,
+			true,
+		},
+		{
+			"Normal buildkite upload with file argument",
+			"buildkite-agent pipeline upload go.mod",
+			true,
 		},
 		{
 			"Simple signed upload",


### PR DESCRIPTION
This updates `verify` to allow `buildkite-agent pipeline upload` to be unsigned. This helps in cases where `buildkite-agent` is a proxy to this tool, or with pipelines that may not use signing (but the upload agent does).