### PR TITLE
Infer the AWS region from the AWS SM ARN

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,9 +9,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -69,7 +66,7 @@ func main() {
 		if awsSharedSecretId != "" {
 			log.Printf("Using secret from AWS SM %s", awsSharedSecretId)
 			var err error
-			signingSecret, err = getAwsSmSecret(awsSharedSecretId)
+			signingSecret, err = GetAwsSmSecret(awsSharedSecretId)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -185,16 +182,4 @@ func getPipelineFromBuildkiteAgent(f *os.File) (interface{}, error) {
 	}
 
 	return parsed, nil
-}
-
-func getAwsSmSecret(secretId string) (string, error) {
-	client := secretsmanager.New(session.New())
-	request := &secretsmanager.GetSecretValueInput {
-		SecretId: aws.String(secretId),
-	}
-	result, err := client.GetSecretValue(request)
-	if err != nil {
-		return "", err
-	}
-	return *result.SecretString, nil
 }

--- a/secrets.go
+++ b/secrets.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+)
+
+func getAwsSmSecretRegion(secretId string) (string, bool) {
+	re := regexp.MustCompile("^arn:aws:secretsmanager:([^:]+):")
+	result := re.FindStringSubmatch(secretId)
+	if result == nil {
+		return "", false
+	}
+	return result[1], true
+}
+
+func GetAwsSmSecret(secretId string) (string, error) {
+	var awsSession *session.Session
+
+	// use the ARN as a hint for the region of the secret rather than the default
+	// this is because the region in the ARN means nothing to AWS SM
+	if secretRegion, hasRegion := getAwsSmSecretRegion(secretId); hasRegion {
+		awsSession = session.Must(session.NewSession(&aws.Config{Region: aws.String(secretRegion)}))
+	} else {
+		awsSession = session.Must(session.NewSession())
+	}
+
+	client := secretsmanager.New(awsSession)
+	request := &secretsmanager.GetSecretValueInput {
+		SecretId: aws.String(secretId),
+	}
+
+	result, err := client.GetSecretValue(request)
+	if err != nil {
+		return "", err
+	}
+	return *result.SecretString, nil
+}

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRegionFromAwsSmArn(t *testing.T) {
+	region, ok := getAwsSmSecretRegion("arn:aws:secretsmanager:ap-southeast-2:1234567:secret:my-global-secret")
+	assert.True(t, ok)
+	assert.Equal(t, "ap-southeast-2", region)
+}
+
+func TestParseRegionFromAwsSmId(t *testing.T) {
+	_, ok := getAwsSmSecretRegion("just-an-id")
+	assert.False(t, ok)
+}
+


### PR DESCRIPTION
This closes #28 by inferring the AWS region from the AWS Secrets Manager ARN rather than the default region.