### PR TITLE
Ensure BUILDKITE_PLUGINS is sorted per canonical extraction

### DIFF
--- a/signer.go
+++ b/signer.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -236,6 +237,20 @@ func (s SharedSecretSigner) Verify(command string, pluginJSON string, expected S
 			return nil
 		}
 		return errors.New("🚨 Signature missing. The provided command is not permitted to be unsigned.")
+	}
+
+	if pluginJSON != "" {
+		// https://golang.org/pkg/encoding/json/#Marshal provides consistent ordering of JSON
+		// unmarshal and remarshal to ensure this ordering is the same as extraction
+		var plugins interface{}
+		if err := json.Unmarshal([]byte(pluginJSON), &plugins); err != nil {
+			return err
+		}
+		pluginBytes, err := json.Marshal(plugins)
+		if err != nil {
+			return err
+		}
+		pluginJSON = string(pluginBytes)
 	}
 
 	// allow signerFunc to be overwritten in tests


### PR DESCRIPTION
This fixes #31 by sorting BUILDKITE_PLUGINS in the same way Go JSON marshaling works:

Golang does this by default: https://golang.org/pkg/encoding/json/#Marshal

> Map values encode as JSON objects. The map's key type must either be a string, an integer type, or implement encoding.TextMarshaler. The map keys are sorted and used as JSON object keys by applying the following rules, subject to the UTF-8 coercion described for string values above:

Huge thanks to @lox for the idea/solution, much simpler than the alternatives.