### PR TITLE
Ensures unsigned commands have no special characters

### DIFF
--- a/unsigned_commands.go
+++ b/unsigned_commands.go
@@ -3,70 +3,42 @@ package main
 import (
 	"strings"
 	"path/filepath"
+	"runtime"
 	"fmt"
 	"os"
 )
 
-func getUploadCommand(command string) (string, bool) {
+const (
+	posixSpecialChars = "!\"#$&'()*,;<=>?[]\\^`{}|~"
+	batchSpecialChars = "^&;,=%"
+)
+
+func isUploadCommand(command string) bool {
 	// buildkite-signed-pipeline upload
 	rawUploadCommand := fmt.Sprintf("%s upload", filepath.Base(os.Args[0]))
 	if strings.HasPrefix(command, rawUploadCommand) {
-		return rawUploadCommand, true
+		return true
 	}
 
-	vanillaUploadCommand := "buildkite-agent pipeline upload"
-	if strings.HasPrefix(command, vanillaUploadCommand) {
-		return vanillaUploadCommand, true
+	// vanilla upload command
+	if strings.HasPrefix(command, "buildkite-agent pipeline upload") {
+		return true
 	}
 
-	return "", false
+	return false
+}
+
+func hasSpecialShellChars(str string) bool {
+	if runtime.GOOS == `windows` {
+		return strings.ContainsAny(str, batchSpecialChars);
+	}
+	return strings.ContainsAny(str, posixSpecialChars);
 }
 
 func IsUnsignedCommandOk(command string) (bool, error) {
-	uploadCommand, ok := getUploadCommand(command)
-	if !ok {
+	if !isUploadCommand(command) {
 		return false, nil
 	}
-
-	// straight upload
-	if uploadCommand == command {
-		return true, nil
-	}
-
-	uploadPrefix := uploadCommand + " "
-	// If there's no additional arguments, bail early
-	if !strings.HasPrefix(command, uploadPrefix) {
-		return false, nil
-	}
-
-	fileArgument := strings.TrimPrefix(command, uploadPrefix)
-	isLocal, err := isWorkingDirectoryFile(fileArgument)
-
-	if err != nil {
-		return false, err
-	}
-
-	return isLocal, nil
-}
-
-func isWorkingDirectoryFile(fileName string) (bool, error) {
-	// this is based on https://github.com/buildkite/agent/blob/cc07aba854e35f0f31b0d743d7ec2829b425bb6a/bootstrap/bootstrap.go#L1013-L1030
-	// and ensures the given filename exists in the working directory
-	workingDirectory, err := os.Getwd()
-	if err != nil {
-		return false, err
-	}
-	pathToFile, err := filepath.Abs(filepath.Join(workingDirectory, fileName))
-	if err != nil {
-		return false, err
-	}
-
-	// Make sure the file is definitely within this working directory
-	return fileExists(pathToFile) &&
-		strings.HasPrefix(pathToFile, workingDirectory + string(os.PathSeparator)), nil
-}
-
-func fileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	return err == nil
+	// ensure no special shell variables are used, this means `buildkite-agent pipeline upload `rm -rf /`` would be disallowed
+	return !hasSpecialShellChars(command), nil
 }


### PR DESCRIPTION
This tool recommends using `buildkite-signed-pipeline verify` in the environment hook, but allows some unsigned commands to pass through, e.g. `buildkite-signed-pipeline upload .buildkite/my-other-pipeline.yml`. 

It used to check that the referenced file (to `buildkite-signed-pipeline upload`) existed, however as this is run in an environment hook this happens before checkout. This changes the unsigned logic to reject upload commands that have special shell characters per the constants in https://github.com/buildkite/shellwords