### PR TITLE
Adds support for commands with list environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ dist/buildkite-signed-pipeline-windows-amd64.exe: $(FILES)
 dist/buildkite-signed-pipeline-darwin-amd64: $(FILES)
 	GOOS=darwin GOARCH=amd64 go build -v -ldflags="$(FLAGS)" -o $@ ./cmd/buildkite-signed-pipeline
 
+.PHONY: test
+test:
+	go test -v $(FILES)
+
 .PHONY: clean
 clean:
 	rm -rf dist/

--- a/cmd/buildkite-signed-pipeline/signer_test.go
+++ b/cmd/buildkite-signed-pipeline/signer_test.go
@@ -106,6 +106,11 @@ func TestPipelines(t *testing.T) {
 			`{"steps":[{"command":"echo Hello \"Fred\"","env":{"EXISTING":"existing-value","STEP_SIGNATURE":"signature(echo Hello \"Fred\",)"}}]}`,
 		},
 		{
+			"Command with existing env list",
+			`{"steps":[{"command":"echo Hello \"Fred\"", "env":["EXISTING=existing-value"]}]}`,
+			`{"steps":[{"command":"echo Hello \"Fred\"","env":["EXISTING=existing-value","STEP_SIGNATURE=signature(echo Hello \"Fred\",)"]}]}`,
+		},
+		{
 			"Pipeline with multiple commands",
 			`{"steps":[{"command":["echo Hello World", "echo Foo Bar"]}]}`,
 			`{"steps":[{"command":["echo Hello World","echo Foo Bar"],"env":{"STEP_SIGNATURE":"signature(echo Hello World\necho Foo Bar,)"}}]}`,


### PR DESCRIPTION
This fixes #35 by checking the environment type, and appending a `key=value` if the environment type is a list.

This means:
```
steps:
   - command: echo foo
      env:
        - KEY=value
```

will now work the same as
```
steps:
   - command: echo foo
      env:
        KEY: value
```
