### PR TITLE
Allow tool to be whitelisted without an extension on Windows

### DIFF
--- a/cmd/buildkite-signed-pipeline/unsigned_commands.go
+++ b/cmd/buildkite-signed-pipeline/unsigned_commands.go
@@ -13,11 +13,25 @@ const (
 	batchSpecialChars = "^&;,=%"
 )
 
+func getToolNames() []string {
+	thisTool := filepath.Base(os.Args[0])
+	toolNames := []string{thisTool}
+
+	// handle both thisTool and thisTool.exe on windows
+	if runtime.GOOS == `windows` {
+		toolNames = append(toolNames, strings.TrimSuffix(thisTool, ".exe"))
+	}
+
+	return toolNames
+}
+
 func isUploadCommand(command string) bool {
-	// buildkite-signed-pipeline upload
-	rawUploadCommand := fmt.Sprintf("%s upload", filepath.Base(os.Args[0]))
-	if strings.HasPrefix(command, rawUploadCommand) {
-		return true
+	for _, toolName := range getToolNames() {
+		// buildkite-signed-pipeline upload
+		rawUploadCommand := fmt.Sprintf("%s upload", toolName)
+		if strings.HasPrefix(command, rawUploadCommand) {
+			return true
+		}
 	}
 
 	// vanilla upload command


### PR DESCRIPTION
This allows this tool to be used as `buildkite-signed-pipeline upload` or `buildkite-signed-pipeline.exe upload` on Windows